### PR TITLE
[on hold] Google Analytics: add support for sending data from server to "app" properties 

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -6,6 +6,7 @@
 var integration = require('segmentio-integration');
 var Universal = require('./universal');
 var Classic = require('./classic');
+var tick = process.nextTick;
 
 /**
  * Expose `GA`
@@ -13,7 +14,7 @@ var Classic = require('./classic');
 
 var GA = module.exports = integration('Google Analytics')
   .ensure('settings.serversideTrackingId')
-  .channels(['server'])
+  .channels(['server']);
 
 /**
  * Initialize
@@ -34,6 +35,7 @@ GA.prototype.track    = proxy('track');
 GA.prototype.identify = proxy('identify');
 GA.prototype.alias    = proxy('alias');
 GA.prototype.page     = proxy('page');
+GA.prototype.screen   = screen();
 
 /**
  * Proxy the method to classic or universal analytics.
@@ -45,5 +47,19 @@ function proxy(method){
   return function(message, fn){
     var ga = this.settings.serversideClassic ? this.classic: this.universal;
     return ga[method].call(ga, message, fn);
+  };
+}
+
+/**
+ * Proxy the method to classic or universal analytics.
+ * @param  {String}   method  ('track', 'identify', etc.)
+ * @return {Function}         the function to use
+ */
+
+function screen(){
+  return function(message, fn){
+    var ga = this.settings.serversideClassic ? null : this.universal;
+    if (ga) return ga.screen(message, fn);
+    return tick(fn);
   };
 }

--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -53,7 +53,6 @@ function proxy(method){
 /**
  * Use screen method if universal
  * or bail if classic
- * 
  * @return {Function} the function to use (or skip)
  */
 

--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -51,9 +51,10 @@ function proxy(method){
 }
 
 /**
- * Proxy the method to classic or universal analytics.
- * @param  {String}   method  ('track', 'identify', etc.)
- * @return {Function}         the function to use
+ * Use screen method if universal
+ * or bail if classic
+ * 
+ * @return {Function} the function to use (or skip)
  */
 
 function screen(){

--- a/lib/google-analytics/mapper.js
+++ b/lib/google-analytics/mapper.js
@@ -35,6 +35,24 @@ exports.page = function(page, settings){
 };
 
 /**
+ * Map screen msg.
+ *
+ * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#screenView
+ *
+ * @param {Screen} screen
+ * @param {Object} settings
+ * @return {Object}
+ */
+
+exports.screen = function(screen, settings){
+  var ret = common(screen, settings);
+  ret.cd = screen.name();
+  ret.t = 'screenview';
+
+  return ret;
+};
+
+/**
  * Track.
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#event
@@ -144,6 +162,8 @@ function common(facade, settings){
   // app
   if (app.name) form.an = app.name;
   if (app.version) form.av = app.version;
+  if (app.appId) form.aid = app.appId;
+  if (app.appInstallerId) form.aiid = app.appInstallerId;
 
   if (settings.sendUserId && facade.userId()) form.uid = facade.userId();
   if (facade.userAgent()) form.ua = facade.userAgent();

--- a/lib/google-analytics/test/fixtures/screen-app.json
+++ b/lib/google-analytics/test/fixtures/screen-app.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "name": "Home",
+    "context": {
+      "app": {
+        "name": "Test App",
+        "version": "1.1",
+        "appId":"com.foo.App",
+        "appInstallerId": "com.android.vending"
+      }
+    }
+  },
+  "output": {
+    "cid": 2710159508,
+    "tid": "UA-27033709-11",
+    "cd": "Home",
+    "t": "screenview",
+    "v": 1,
+    "an": "Test App",
+    "av": "1.1",
+    "aid": "com.foo.App",
+    "aiid": "com.android.vending"
+  }
+}

--- a/lib/google-analytics/test/fixtures/screen-basic.json
+++ b/lib/google-analytics/test/fixtures/screen-basic.json
@@ -1,0 +1,14 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "name": "Home"
+  },
+  "output": {
+    "cid": 2710159508,
+    "tid": "UA-27033709-11",
+    "cd": "Home",
+    "t": "screenview",
+    "v": 1
+  }
+}

--- a/lib/google-analytics/test/index.js
+++ b/lib/google-analytics/test/index.js
@@ -62,6 +62,16 @@ describe('Google Analytics', function(){
     });
 
     describe('mapper', function(){
+      describe('screen', function(){
+        it('should map basic screen', function(){
+          test.maps('screen-basic', settings);
+        });
+
+        it('should map screen with context.app', function(){
+          test.maps('screen-app', settings);
+        });
+      });
+
       describe('page', function(){
         it('should map basic page', function(){
           test.maps('page-basic', settings);
@@ -182,6 +192,27 @@ describe('Google Analytics', function(){
       });
     });
 
+    describe('.screen()', function(){
+      it('should get a good response from the API', function(done){
+        var json = test.fixture('screen-basic');
+        test
+          .set(settings)
+          .screen(json.input)
+          .sends(json.output)
+          .expects(200, done);
+      });
+
+      it('should send app context', function(done){
+        var json = test.fixture('screen-app');
+        test
+          .set(settings)
+          .set(json.settings)
+          .screen(json.input)
+          .sends(json.output)
+          .expects(200, done);
+      });
+    });
+
     describe('.completedOrder()', function(){
       it('should send ecommerce data', function(done){
         var track = helpers.transaction();
@@ -244,5 +275,16 @@ describe('Google Analytics', function(){
           .end(done);
       });
     });
+    describe('.screen()', function(){
+      it('should do nothing', function(done){
+        var screen = helpers.screen();
+
+        test
+          .set(settings)
+          .screen(screen)
+          .end(done);
+      });
+    });
+
   });
 });

--- a/lib/google-analytics/universal.js
+++ b/lib/google-analytics/universal.js
@@ -34,6 +34,23 @@ GA.prototype.track = function (track, callback) {
 };
 
 /**
+ * Screen.
+ *
+ * @param {Screen} screen
+ * @param {Function} callback
+ */
+
+GA.prototype.screen = function (screen, callback) {
+  var payload = mapper.screen(screen, this.settings);
+  return this
+    .post()
+    .type('form')
+    .send(payload)
+    .end(this.handle(callback));
+};
+
+
+/**
  * Completed Order.
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#ecom


### PR DESCRIPTION
*Background*: Our implementation of the GA measurement protocol dictated that we could only send data to "web" properties. This meant that our Xamarin users, anyone who wanted to use our "light" mobile SDKs, or anyone proxying their app data through their own servers and using our server-side libraries (lots of cordova users) had a degraded experience. They had to use GA web properties to look at their app data. Now they can use app properties!

Turns out the reason this was the case was because we were only mapping page calls and sending "pageviews," and app views expect "screenviews."

https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#screenView

Quick video with some end to end testing (1 screenview 1 event) showing this working as expected: https://cloudup.com/cx-DG5xIl5B

thoughts? happy to field any questions. @amillet89 @calvinfo @ianstormtaylor @DirtyAnalytics @yields 










